### PR TITLE
Replace TensorFlow/Keras with PyTorch for both the localizer and decoder stages.

### DIFF
--- a/pipeline/config.ini
+++ b/pipeline/config.ini
@@ -11,3 +11,4 @@ attributes_path=localizer_2019_attributes.json
 confidence_threshold=0.5
 imgsz=640
 nms_radius=30
+device=auto

--- a/pipeline/config.ini
+++ b/pipeline/config.ini
@@ -2,5 +2,12 @@
 model_path=decoder_2019_keras3.h5
 
 [Localizer]
-model_path=localizer_2019_keras3.h5
+model_path=localizer_2019_weights.pt
 attributes_path=localizer_2019_attributes.json
+
+[PoloLocalizer]
+polo_model_path=polo_feeder_weights.pt
+attributes_path=localizer_2019_attributes.json
+confidence_threshold=0.5
+imgsz=640
+nms_radius=30

--- a/pipeline/config.ini
+++ b/pipeline/config.ini
@@ -1,5 +1,5 @@
 [Decoder]
-model_path=decoder_2019_keras3.h5
+model_path=decoder_2019_weights.pt
 
 [Localizer]
 model_path=localizer_2019_weights.pt

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -23,7 +23,7 @@ class VideoReader:
     def __init__(
         self,
         video_path,
-        ffmpeg_stderr_fd=None,
+        ffmpeg_stderr_fd=sp.DEVNULL,
         format="guess_on_ext",
         ffmpeg_bin="ffmpeg",
         ffprobe_bin="ffprobe",

--- a/pipeline/io.py
+++ b/pipeline/io.py
@@ -102,7 +102,7 @@ class VideoReader:
 
         self.frames += 1
 
-        image = np.fromstring(raw_image, dtype="uint8")
+        image = np.frombuffer(raw_image, dtype="uint8")
         image = image.reshape((self.h, self.w))
         self.video_pipe.stdout.flush()
         return image

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -222,7 +222,7 @@ def _get_cache_dir(name):
 
 def download_models(config):
     new_config = copy.copy(config)
-    for stage_name in ("Localizer", "Decoder"):
+    for stage_name in ("Localizer", "Decoder", "PoloLocalizer"):
         if stage_name not in config:
             continue
         stage_config = new_config[stage_name]

--- a/pipeline/scripts/bb_pipeline.py
+++ b/pipeline/scripts/bb_pipeline.py
@@ -31,8 +31,8 @@ def process_video(args):
         text_root_path (str): Root path for any text-based metadata associated with the video.
 
     Optional Attributes (handled by `getattr`):
-        decoder_model_path (str, optional): Path to the decoder model (e.g., `decoder_2019_keras3.h5`).
-        localizer_model_path (str, optional): Path to the localizer model (e.g., `localizer_2019_keras3.h5`).
+        decoder_model_path (str, optional): Path to the decoder model (e.g., `decoder_2019_weights.pt`).
+        localizer_model_path (str, optional): Path to the localizer model (e.g., `localizer_2019_weights.pt`).
         localizer_attributes_path (str, optional): Path to the localizer attributes JSON file (e.g., `localizer_2019_attributes.json`).
         video_file_type (str, optional): Format type for the video file; defaults to 'auto'.
         progressbar (bool, optional): If `True`, enables a progress bar display for processing.

--- a/pipeline/stages/__init__.py
+++ b/pipeline/stages/__init__.py
@@ -1,4 +1,5 @@
 from pipeline.stages import stage
+from pipeline.stages.polo_localizer import PoloLocalizer
 from pipeline.stages.processing import (
     Decoder,
     ImageReader,
@@ -18,6 +19,7 @@ Stages = (
     ImageReader,
     LocalizerPreprocessor,
     Localizer,
+    PoloLocalizer,
     Decoder,
     ResultMerger,
     LocalizerVisualizer,

--- a/pipeline/stages/decoder_torch.py
+++ b/pipeline/stages/decoder_torch.py
@@ -1,0 +1,166 @@
+"""PyTorch implementation of the BeesBook tag decoder (custom ResNet-50).
+
+Mirrors the Keras architecture defined in
+``bb_pipeline_models/models/model_generation/pipelinemodels.py:get_custom_resnet``.
+
+Module names match the Keras H5 layer names (e.g. ``res3a_branch2a``,
+``bn3a_branch2a``, ``bit_0``) so weight conversion is a direct name mapping.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class DecoderResNet(nn.Module):
+    """BeesBook tag decoder — custom ResNet-50 with 16 output heads.
+
+    Input:  (B, 1, 32, 32) grayscale float32 in [0, 1]
+    Output: list of 16 tensors matching Keras ``model.predict()`` order:
+            [bit_0, ..., bit_11, x_rotation, y_rotation, z_rotation, center]
+
+    Note: BatchNorm uses ``eps=1e-3`` to match the Keras default.
+    """
+
+    # Keras BatchNormalization default epsilon (PyTorch default is 1e-5)
+    _bn_eps = 1e-3
+
+    # Stage configurations: (stage, block, filters, stride, has_shortcut_projection)
+    _stages = [
+        # stage 2b: identity block
+        (2, "b", [16, 16, 64], 1, False),
+        # stage 3
+        (3, "a", [32, 32, 128], 2, True),
+        (3, "b", [32, 32, 128], 1, False),
+        # stage 4
+        (4, "a", [64, 64, 256], 2, True),
+        (4, "b", [64, 64, 256], 1, False),
+        # stage 5
+        (5, "a", [128, 128, 512], 2, True),
+        (5, "b", [128, 128, 512], 1, False),
+        # stage 6
+        (6, "a", [256, 256, 1024], 2, True),
+        (6, "b", [256, 256, 1024], 1, False),
+    ]
+
+    def __init__(self):
+        super().__init__()
+
+        # ── Stage 2a (manual — matches inline code in get_custom_resnet) ──
+        # Main branch: input(1) → 1×1 conv → 3×3 conv → 1×1 conv
+        self.res2a_branch2a = nn.Conv2d(1, 16, kernel_size=1, bias=True)
+        self.bn2a_branch2a = nn.BatchNorm2d(16, eps=self._bn_eps)
+        self.res2a_branch2b = nn.Conv2d(16, 16, kernel_size=3, padding=1, bias=True)
+        self.bn2a_branch2b = nn.BatchNorm2d(16, eps=self._bn_eps)
+        self.res2a_branch2c = nn.Conv2d(16, 64, kernel_size=1, bias=True)
+        self.bn2a_branch2c = nn.BatchNorm2d(64, eps=self._bn_eps)
+        # Shortcut branch: input(1) → 1×1 conv
+        self.res2a_branch1 = nn.Conv2d(1, 64, kernel_size=1, bias=True)
+        self.bn2a_branch1 = nn.BatchNorm2d(64, eps=self._bn_eps)
+
+        # ── Stages 2b through 6b ──
+        in_channels = 64
+        for stage, block, (f1, f2, f3), stride, has_proj in self._stages:
+            prefix = f"res{stage}{block}_branch"
+            bn_prefix = f"bn{stage}{block}_branch"
+
+            # Main branch: 1×1 → 3×3 → 1×1
+            setattr(self, f"{prefix}2a",
+                    nn.Conv2d(in_channels, f1, kernel_size=1, stride=stride, bias=True))
+            setattr(self, f"{bn_prefix}2a", nn.BatchNorm2d(f1, eps=self._bn_eps))
+
+            setattr(self, f"{prefix}2b",
+                    nn.Conv2d(f1, f2, kernel_size=3, padding=1, bias=True))
+            setattr(self, f"{bn_prefix}2b", nn.BatchNorm2d(f2, eps=self._bn_eps))
+
+            setattr(self, f"{prefix}2c",
+                    nn.Conv2d(f2, f3, kernel_size=1, bias=True))
+            setattr(self, f"{bn_prefix}2c", nn.BatchNorm2d(f3, eps=self._bn_eps))
+
+            # Shortcut projection (convolutional blocks only)
+            if has_proj:
+                setattr(self, f"{prefix}1",
+                        nn.Conv2d(in_channels, f3, kernel_size=1, stride=stride, bias=True))
+                setattr(self, f"{bn_prefix}1", nn.BatchNorm2d(f3, eps=self._bn_eps))
+
+            in_channels = f3
+
+        # ── Global average pooling ──
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+
+        # ── 16 output heads ──
+        for i in range(12):
+            setattr(self, f"bit_{i}", nn.Linear(1024, 1))
+        self.x_rotation = nn.Linear(1024, 2)
+        self.y_rotation = nn.Linear(1024, 2)
+        self.z_rotation = nn.Linear(1024, 2)
+        self.center = nn.Linear(1024, 2)
+
+    def _bottleneck(self, x, stage, block, has_proj):
+        """Run one bottleneck block (convolutional or identity)."""
+        prefix = f"res{stage}{block}_branch"
+        bn_prefix = f"bn{stage}{block}_branch"
+
+        shortcut = x
+
+        # Branch 2: 1×1 → BN → ReLU → 3×3 → BN → ReLU → 1×1 → BN
+        out = getattr(self, f"{prefix}2a")(x)
+        out = getattr(self, f"{bn_prefix}2a")(out)
+        out = F.relu(out)
+
+        out = getattr(self, f"{prefix}2b")(out)
+        out = getattr(self, f"{bn_prefix}2b")(out)
+        out = F.relu(out)
+
+        out = getattr(self, f"{prefix}2c")(out)
+        out = getattr(self, f"{bn_prefix}2c")(out)
+
+        # Shortcut projection
+        if has_proj:
+            shortcut = getattr(self, f"{prefix}1")(shortcut)
+            shortcut = getattr(self, f"{bn_prefix}1")(shortcut)
+
+        return F.relu(out + shortcut)
+
+    def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor, shape (B, 1, 32, 32)
+            Grayscale input in NCHW format.
+
+        Returns
+        -------
+        list of 16 Tensors
+            [bit_0(B,1), ..., bit_11(B,1),
+             x_rotation(B,2), y_rotation(B,2), z_rotation(B,2),
+             center(B,2)]
+        """
+        # Stage 2a (manual)
+        shortcut = self.bn2a_branch1(self.res2a_branch1(x))
+
+        out = F.relu(self.bn2a_branch2a(self.res2a_branch2a(x)))
+        out = F.relu(self.bn2a_branch2b(self.res2a_branch2b(out)))
+        out = self.bn2a_branch2c(self.res2a_branch2c(out))
+
+        x = F.relu(out + shortcut)
+
+        # Stages 2b through 6b
+        for stage, block, _, _, has_proj in self._stages:
+            x = self._bottleneck(x, stage, block, has_proj)
+
+        # Pool → flatten
+        x = self.avg_pool(x).flatten(1)  # (B, 1024)
+
+        # Output heads
+        bits = [torch.sigmoid(getattr(self, f"bit_{i}")(x)) for i in range(12)]
+        rotations = [
+            self.x_rotation(x),
+            self.y_rotation(x),
+            self.z_rotation(x),
+        ]
+        center = self.center(x)
+
+        return bits + rotations + [center]

--- a/pipeline/stages/localizer_torch.py
+++ b/pipeline/stages/localizer_torch.py
@@ -1,0 +1,95 @@
+"""
+PyTorch port of the BeesBook localizer FCN (LocalizerEncoder).
+
+This is a direct port of the Keras model defined in
+bb_localizer/localizer/model.py (get_conv_model, initial_channels=16).
+
+Architecture (all convolutions use valid/no padding):
+  - 3 strided Conv2d (stride=2) for spatial downsampling
+  - 4 bottleneck Conv2d (stride=1) blocks
+  - 1 expansion Conv2d
+  - 2-layer 1×1 head with sigmoid output
+
+For a 128×128 input the output is 5×5 with 4 channels (one per class).
+Stride=8, offset=47 in image-coordinate space.
+
+Layer names and shapes match localizer_2019_weights.pt (state dict compatible):
+  conv0            (16,  1, 3, 3)  stride=2, no BN
+  conv1 + bn1      (32, 16, 3, 3)  stride=2
+  conv2 + bn2      (64, 32, 3, 3)  stride=2
+  conv3 + bn3      (64, 64, 3, 3)  stride=1  ┐
+  conv4 + bn4      (64, 64, 3, 3)  stride=1  │ bottleneck
+  conv5 + bn5      (64, 64, 3, 3)  stride=1  │
+  conv6 + bn6      (64, 64, 3, 3)  stride=1  ┘
+  conv_expand + bn_expand  (128, 64, 3, 3)  stride=1
+  conv_reduce      (16, 128, 1, 1)  head, ReLU
+  conv_out         ( 4,  16, 1, 1)  head, Sigmoid
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class LocalizerEncoder(nn.Module):
+    """Fully-convolutional bee localizer, PyTorch port of the BeesBook Keras FCN.
+
+    Forward pass order matches the Keras model: Conv → ReLU → BN → Dropout.
+    At inference (model.eval()) Dropout is a no-op.
+
+    Input:  (B, 1, H, W)  float32 in [0, 1]  — grayscale, NCHW
+    Output: (B, 4, H', W') float32 in [0, 1]  — per-class saliency heatmap, NCHW
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        # Downsampling blocks (stride=2, valid padding)
+        self.conv0 = nn.Conv2d(1, 16, 3, stride=2, padding=0)   # no BN after this one
+
+        self.conv1 = nn.Conv2d(16, 32, 3, stride=2, padding=0)
+        self.bn1   = nn.BatchNorm2d(32)
+
+        self.conv2 = nn.Conv2d(32, 64, 3, stride=2, padding=0)
+        self.bn2   = nn.BatchNorm2d(64)
+
+        # Bottleneck blocks (stride=1, valid padding)
+        self.conv3 = nn.Conv2d(64, 64, 3, padding=0)
+        self.bn3   = nn.BatchNorm2d(64)
+
+        self.conv4 = nn.Conv2d(64, 64, 3, padding=0)
+        self.bn4   = nn.BatchNorm2d(64)
+
+        self.conv5 = nn.Conv2d(64, 64, 3, padding=0)
+        self.bn5   = nn.BatchNorm2d(64)
+
+        self.conv6 = nn.Conv2d(64, 64, 3, padding=0)
+        self.bn6   = nn.BatchNorm2d(64)
+
+        # Expansion block
+        self.conv_expand = nn.Conv2d(64, 128, 3, padding=0)
+        self.bn_expand   = nn.BatchNorm2d(128)
+
+        # 1×1 head
+        self.conv_reduce = nn.Conv2d(128, 16, 1)
+        self.conv_out    = nn.Conv2d(16,   4, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Downsampling
+        x = F.dropout2d(F.relu(self.conv0(x)), p=0.1, training=self.training)
+        x = F.dropout2d(self.bn1(F.relu(self.conv1(x))), p=0.1, training=self.training)
+        x = F.dropout2d(self.bn2(F.relu(self.conv2(x))), p=0.1, training=self.training)
+
+        # Bottleneck
+        x = F.dropout2d(self.bn3(F.relu(self.conv3(x))), p=0.1, training=self.training)
+        x = F.dropout2d(self.bn4(F.relu(self.conv4(x))), p=0.1, training=self.training)
+        x = F.dropout2d(self.bn5(F.relu(self.conv5(x))), p=0.1, training=self.training)
+        x = self.bn6(F.relu(self.conv6(x)))           # no dropout on last bottleneck
+
+        # Expansion
+        x = self.bn_expand(F.relu(self.conv_expand(x)))
+
+        # 1×1 head
+        x = torch.sigmoid(self.conv_out(F.relu(self.conv_reduce(x))))
+
+        return x

--- a/pipeline/stages/polo_localizer.py
+++ b/pipeline/stages/polo_localizer.py
@@ -1,0 +1,300 @@
+"""
+POLO-based bee localizer stage for the BeesBook pipeline.
+
+Uses a TorchScript-exported POLO model (a YOLOv8-based point detector from
+mooch443/POLO) for multi-class bee detection. POLO natively outputs
+per-detection class predictions, so no separate crop classifier is needed.
+
+Provides the same output contract as the heatmap-based Localizer stage:
+  SaliencyImages, TagRegions, TagSaliencies, TagLocalizerPositions,
+  BeeRegions, BeeSaliencies, BeeLocalizerPositions, BeeTypes
+
+Requires only PyTorch at runtime (no ultralytics dependency).
+Export the POLO .pt model to TorchScript first:
+
+    from ultralytics import YOLO
+    import torch
+    model = YOLO("polo26_feedercams.pt")
+    scripted = torch.jit.trace(model.model,
+                               torch.randn(1, 3, 640, 640).to(model.device))
+    torch.jit.save(scripted, "polo26_feedercams.torchscript")
+"""
+
+import json
+
+import cv2
+import numpy as np
+import torch
+
+from pipeline.objects import (
+    BeeLocalizerPositions,
+    BeeRegions,
+    BeeSaliencies,
+    BeeTypes,
+    LocalizerInputImage,
+    LocalizerShapes,
+    PaddedImage,
+    SaliencyImages,
+    TagLocalizerPositions,
+    TagRegions,
+    TagSaliencies,
+)
+from pipeline.stages.processing import InitializedPipelineStage, Localizer, point_nms
+
+# Default POLO class names matching standard POLO training.
+_DEFAULT_POLO_CLASS_NAMES = {
+    0: "UnmarkedBee",
+    1: "MarkedBee",
+    2: "BeeInCell",
+    3: "UpsideDownBee",
+}
+
+
+def _letterbox(img, new_shape=(640, 640)):
+    """Resize + pad image to *new_shape*, preserving aspect ratio.
+
+    Matches the ultralytics ``LetterBox`` transform (``auto=False``).
+
+    Returns:
+        img_padded: Letterboxed image (*new_shape* HWC).
+        scale: Scale factor applied.
+        pad: ``(dw, dh)`` float padding offsets for coordinate inversion.
+    """
+    h, w = img.shape[:2]
+    target_h, target_w = new_shape
+    scale = min(target_h / h, target_w / w)
+
+    new_unpad_w = int(round(w * scale))
+    new_unpad_h = int(round(h * scale))
+
+    dw = (target_w - new_unpad_w) / 2.0
+    dh = (target_h - new_unpad_h) / 2.0
+
+    if (new_unpad_h, new_unpad_w) != (h, w):
+        img = cv2.resize(img, (new_unpad_w, new_unpad_h),
+                         interpolation=cv2.INTER_LINEAR)
+
+    top = int(round(dh - 0.1))
+    bottom = int(round(dh + 0.1))
+    left = int(round(dw - 0.1))
+    right = int(round(dw + 0.1))
+
+    img = cv2.copyMakeBorder(
+        img, top, bottom, left, right,
+        cv2.BORDER_CONSTANT, value=(114, 114, 114),
+    )
+    return img, scale, (dw, dh)
+
+
+def _postprocess(pred_tensor, conf_threshold, scale, pad):
+    """Decode raw POLO output into detections in original image coordinates.
+
+    Args:
+        pred_tensor: ``(1, 2+C, N)`` tensor — ``[x, y, cls0, cls1, ...]``
+            in letterbox pixel space.
+        conf_threshold: Minimum detection confidence.
+        scale: Letterbox scale factor.
+        pad: ``(dw, dh)`` letterbox padding.
+
+    Returns:
+        positions_xy: ``(M, 2)`` float32 array of ``(x, y)`` in original
+            (pre-letterbox) image coordinates.
+        confidences: ``(M,)`` float32 confidence scores.
+        class_ids: ``(M,)`` int64 class IDs.
+    """
+    pred = pred_tensor[0].T          # (N, 2+C)
+    xy = pred[:, :2]                 # (N, 2)  x, y in letterbox space
+    cls_scores = pred[:, 2:]         # (N, C)
+
+    conf, cls_id = cls_scores.max(dim=1)
+
+    mask = conf >= conf_threshold
+    xy = xy[mask]
+    conf = conf[mask]
+    cls_id = cls_id[mask]
+
+    if len(xy) == 0:
+        return (
+            np.empty((0, 2), dtype=np.float32),
+            np.empty((0,), dtype=np.float32),
+            np.empty((0,), dtype=np.int64),
+        )
+
+    dw, dh = pad
+    xy_np = xy.cpu().numpy().astype(np.float64)
+    xy_np[:, 0] = (xy_np[:, 0] - dw) / scale
+    xy_np[:, 1] = (xy_np[:, 1] - dh) / scale
+
+    return (
+        xy_np.astype(np.float32),
+        conf.cpu().numpy(),
+        cls_id.cpu().numpy(),
+    )
+
+
+class PoloLocalizer(InitializedPipelineStage):
+    """Multi-class point-detection localizer using a TorchScript POLO model.
+
+    Drop-in replacement for the heatmap-based Localizer. POLO detects bees
+    and classifies them (MarkedBee, UnmarkedBee, BeeInCell, UpsideDownBee) in
+    a single forward pass. MarkedBee detections are passed to the Decoder for
+    barcode reading, just like the heatmap localizer.
+
+    The model is loaded via ``torch.jit.load`` — no ultralytics dependency.
+    """
+
+    requires = [LocalizerInputImage, PaddedImage, LocalizerShapes]
+    provides = [
+        SaliencyImages,
+        TagRegions,
+        TagSaliencies,
+        TagLocalizerPositions,
+        BeeRegions,
+        BeeSaliencies,
+        BeeLocalizerPositions,
+        BeeTypes,
+    ]
+
+    def __init__(self, polo_model_path, attributes_path,
+                 confidence_threshold=0.5, imgsz=640, nms_radius=0,
+                 polo_class_names=None):
+        super().__init__()
+
+        self.device = torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self.model = torch.jit.load(
+            str(polo_model_path), map_location=self.device
+        )
+        self.model.eval()
+
+        self.confidence_threshold = float(confidence_threshold)
+        self.imgsz = int(imgsz)
+        self.nms_radius = float(nms_radius)
+
+        # Class-name mapping {int_id: "ClassName"}.
+        if polo_class_names is not None:
+            if isinstance(polo_class_names, str):
+                polo_class_names = json.loads(polo_class_names)
+            self.polo_class_names = {
+                int(k): v for k, v in polo_class_names.items()
+            }
+        else:
+            self.polo_class_names = dict(_DEFAULT_POLO_CLASS_NAMES)
+
+        with open(attributes_path, 'r') as f:
+            attributes = json.load(f)
+            self.class_labels = attributes['class_labels']
+
+    def call(self, image, orig_image, shapes):
+        roi_size = shapes["roi_size"]
+        pad_size = shapes["pad_size"]
+
+        # POLO expects 3-channel input; replicate grayscale to RGB.
+        if image.ndim == 2:
+            image_rgb = np.stack([image, image, image], axis=-1)
+        else:
+            image_rgb = image
+
+        # --- Letterbox preprocessing ---
+        target = (self.imgsz, self.imgsz)
+        img_lb, scale, pad = _letterbox(image_rgb, target)
+
+        # HWC uint8 → CHW float32 [0, 1] → batched tensor
+        img_t = img_lb.transpose(2, 0, 1).astype(np.float32) / 255.0
+        img_t = torch.from_numpy(img_t).unsqueeze(0).to(self.device)
+
+        # --- Forward pass ---
+        with torch.no_grad():
+            raw = self.model(img_t)
+        # TorchScript output is (pred_tensor, feature_maps); keep only [0].
+        pred_tensor = raw[0] if isinstance(raw, (tuple, list)) else raw
+
+        # --- Decode predictions ---
+        positions_xy, conf, cls_ids = _postprocess(
+            pred_tensor, self.confidence_threshold, scale, pad,
+        )
+
+        class_names = np.array(
+            [self.polo_class_names.get(int(c), "Unknown") for c in cls_ids]
+        )
+
+        # Parse detections into (positions, confidences, class_names).
+        # positions_xy[:,0]=x (col), positions_xy[:,1]=y (row) in the
+        # padded-input-image coordinate space (letterbox was undone above).
+        if len(positions_xy) > 0:
+            # Convert (x, y) → pipeline (row, col) convention.
+            padded_positions = np.stack(
+                [positions_xy[:, 1], positions_xy[:, 0]], axis=1,
+            )  # (N, 2) as (row, col) in padded-image coords
+            positions_img = padded_positions - pad_size  # original image coords
+            confidences = conf[:, np.newaxis]            # (N, 1)
+
+            # Cross-class NMS: suppress duplicates at the same location.
+            if self.nms_radius > 0:
+                keep = point_nms(
+                    padded_positions, conf, self.nms_radius,
+                    class_names=class_names, class_agnostic=True,
+                )
+                padded_positions = padded_positions[keep]
+                positions_img = positions_img[keep]
+                confidences = confidences[keep]
+                class_names = class_names[keep]
+        else:
+            padded_positions = np.empty((0, 2), dtype=np.float32)
+            positions_img = np.empty((0, 2), dtype=np.float32)
+            confidences = np.zeros((0, 1), dtype=np.float32)
+            class_names = np.array([], dtype='<U20')
+
+        # Split detections into MarkedBee (→ tag results for Decoder)
+        # and all other classes (→ bee results).
+        tag_mask = class_names == "MarkedBee"
+        bee_mask = ~tag_mask
+
+        # --- Tag (MarkedBee) results ---
+        tag_padded = padded_positions[tag_mask]
+        tag_pos = positions_img[tag_mask]
+        tag_conf = confidences[tag_mask]
+
+        if len(tag_padded) > 0:
+            tag_rois, roi_mask = Localizer.extract_rois(
+                tag_padded, orig_image, roi_size
+            )
+            tag_rois = tag_rois.astype(np.float32) / 255.0
+            tag_pos = tag_pos[roi_mask]
+            tag_conf = tag_conf[roi_mask]
+        else:
+            tag_rois = np.empty(shape=(0, 0, 0, 0))
+
+        tag_results = [tag_rois, tag_conf, tag_pos]
+
+        # --- Bee (non-MarkedBee) results ---
+        bee_padded = padded_positions[bee_mask]
+        bee_pos_all = positions_img[bee_mask]
+        bee_conf_all = confidences[bee_mask]
+        bee_types_all = class_names[bee_mask]
+
+        if len(bee_padded) > 0:
+            bee_rois, roi_mask = Localizer.extract_rois(
+                bee_padded, orig_image, roi_size
+            )
+            bee_rois = bee_rois.astype(np.float32) / 255.0
+            bee_positions = bee_pos_all[roi_mask]
+            bee_saliencies = bee_conf_all[roi_mask]
+            bee_types = bee_types_all[roi_mask]
+        else:
+            bee_rois = np.ndarray(shape=(0, 0, 0, 0))
+            bee_saliencies = np.ndarray(shape=(0, 0, 0, 0))
+            bee_positions = np.ndarray(shape=(0, 0, 0))
+            bee_types = np.ndarray(shape=(0,))
+
+        # Dummy saliency image — POLO does not produce heatmaps.
+        saliency_images = np.zeros(
+            (1, 1, len(self.class_labels)), dtype=np.float32
+        )
+
+        return (
+            [saliency_images]
+            + tag_results
+            + [bee_rois, bee_saliencies, bee_positions, bee_types]
+        )

--- a/pipeline/stages/polo_localizer.py
+++ b/pipeline/stages/polo_localizer.py
@@ -157,16 +157,16 @@ class PoloLocalizer(InitializedPipelineStage):
 
     def __init__(self, polo_model_path, attributes_path,
                  confidence_threshold=0.5, imgsz=640, nms_radius=0,
-                 polo_class_names=None):
+                 polo_class_names=None, device="auto"):
         super().__init__()
 
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu"
-        )
+        self.device = self._resolve_device(device)
         self.model = torch.jit.load(
             str(polo_model_path), map_location=self.device
         )
+        self.model = self.model.to(self.device)
         self.model.eval()
+        self._cpu_fallback_triggered = False
 
         self.confidence_threshold = float(confidence_threshold)
         self.imgsz = int(imgsz)
@@ -185,6 +185,27 @@ class PoloLocalizer(InitializedPipelineStage):
         with open(attributes_path, 'r') as f:
             attributes = json.load(f)
             self.class_labels = attributes['class_labels']
+
+    @staticmethod
+    def _resolve_device(device):
+        if isinstance(device, torch.device):
+            return device
+        requested = str(device).strip().lower() if device is not None else "auto"
+        if requested in ("", "auto"):
+            return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if requested.startswith("cuda") and not torch.cuda.is_available():
+            print("[POLO] cuda requested but unavailable; using cpu instead")
+            return torch.device("cpu")
+        return torch.device(requested)
+
+    @staticmethod
+    def _is_cross_device_torchscript_error(exc):
+        msg = str(exc).lower()
+        return (
+            "expected all tensors to be on the same device" in msg
+            and "cuda" in msg
+            and "cpu" in msg
+        )
 
     def call(self, image, orig_image, shapes):
         roi_size = shapes["roi_size"]
@@ -206,7 +227,19 @@ class PoloLocalizer(InitializedPipelineStage):
 
         # --- Forward pass ---
         with torch.no_grad():
-            raw = self.model(img_t)
+            try:
+                raw = self.model(img_t)
+            except RuntimeError as exc:
+                if self.device.type != "cuda" or not self._is_cross_device_torchscript_error(exc):
+                    raise
+
+                if not self._cpu_fallback_triggered:
+                    print("[POLO] TorchScript CUDA/CPU mismatch; retrying on CPU")
+                    self._cpu_fallback_triggered = True
+                self.device = torch.device("cpu")
+                self.model = self.model.to(self.device)
+                img_t = img_t.to(self.device)
+                raw = self.model(img_t)
         # TorchScript output is (pred_tensor, feature_maps); keep only [0].
         pred_tensor = raw[0] if isinstance(raw, (tuple, list)) else raw
 

--- a/pipeline/stages/processing.py
+++ b/pipeline/stages/processing.py
@@ -4,11 +4,17 @@ import numbers
 import cv2
 import numpy as np
 import skimage
-import tensorflow as tf
+import torch
+import torch.nn.functional as torch_F
 from scipy.ndimage import zoom as scipy_zoom
+from scipy.spatial import cKDTree
 from skimage.exposure import equalize_hist
 from skimage.feature import peak_local_max
 from skimage.io import imread
+
+# TensorFlow is still required for the Decoder stage (Keras ResNet).
+# TODO: migrate Decoder to PyTorch and remove this import
+#   (see bb_pipeline_models/models/model_generation/pipelinemodels.py → get_custom_resnet).
 import tensorflow as tf
 load_model = tf.keras.models.load_model
 
@@ -34,21 +40,61 @@ from pipeline.objects import (
     TagSaliencies,
     Timestamp,
 )
+from pipeline.stages.localizer_torch import LocalizerEncoder
 from pipeline.stages.stage import PipelineStage
 
 from bb_binary import parse_image_fname
 
+# Configure TF GPU memory growth for the Decoder.
 gpus = tf.config.experimental.list_physical_devices("GPU")
 if gpus:
     try:
-        # Currently, memory growth needs to be the same across GPUs
         for gpu in gpus:
             tf.config.experimental.set_memory_growth(gpu, True)
         logical_gpus = tf.config.experimental.list_logical_devices("GPU")
         print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
     except RuntimeError as e:
-        # Memory growth must be set before GPUs have been initialized
         print(e)
+
+
+def point_nms(positions, confidences, radius, class_names=None, class_agnostic=True):
+    """Distance-based non-maximum suppression for point detections.
+
+    Greedy algorithm: iterate detections from highest to lowest confidence.
+    For each kept detection, suppress all lower-confidence detections within
+    ``radius`` pixels.
+
+    Args:
+        positions:     (N, 2) array of (row, col) coordinates.
+        confidences:   (N,) array of confidence scores.
+        radius:        Suppression radius in pixels.
+        class_names:   (N,) array of class label strings.  Required when
+                       class_agnostic is False.
+        class_agnostic: If True, suppress across all classes.  If False, only
+                       suppress detections of the same class.
+
+    Returns:
+        keep: (N,) boolean mask — True for detections that survive.
+    """
+    n = len(positions)
+    if n == 0:
+        return np.zeros(0, dtype=bool)
+
+    order = np.argsort(-confidences)
+    tree = cKDTree(positions)
+    suppressed = np.zeros(n, dtype=bool)
+
+    for idx in order:
+        if suppressed[idx]:
+            continue
+        neighbors = tree.query_ball_point(positions[idx], r=radius)
+        for nb in neighbors:
+            if nb == idx or suppressed[nb]:
+                continue
+            if class_agnostic or class_names[nb] == class_names[idx]:
+                suppressed[nb] = True
+
+    return ~suppressed
 
 
 def zoom(image, zoom_factor, gpu=True):
@@ -63,15 +109,12 @@ def zoom(image, zoom_factor, gpu=True):
 
     assert image.ndim == 2
 
-    target_shape = np.round(np.array(image.shape) * (zoom_factor))
-    target_shape = target_shape.astype(int)
+    target_shape = np.round(np.array(image.shape) * zoom_factor).astype(int)
 
-    img = tf.expand_dims(tf.convert_to_tensor(np.expand_dims(image, axis=-1), dtype=tf.float32), axis=0)
-    img_zoom = tf.image.resize(img, target_shape, method="bicubic")
+    img_t = torch.from_numpy(image).float().unsqueeze(0).unsqueeze(0)  # (1, 1, H, W)
+    img_zoom = torch_F.interpolate(img_t, size=tuple(target_shape), mode="bicubic", align_corners=False)
 
-    processed = img_zoom[0,:,:,0].numpy()  # Convert back to NumPy array
-
-    return processed
+    return img_zoom[0, 0].numpy()
 
 
 class InitializedPipelineStage(PipelineStage):
@@ -154,8 +197,12 @@ class Localizer(InitializedPipelineStage):
 
     def __init__(self, model_path, attributes_path, thresholds={}):
         super().__init__()
-        self.model = load_model(model_path, compile=False)
-        self.model.make_predict_function()
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = LocalizerEncoder().to(self.device)
+        self.model.load_state_dict(
+            torch.load(model_path, map_location=self.device, weights_only=True)
+        )
+        self.model.eval()
 
         with open(attributes_path, 'r') as f:
             attributes = json.load(f)
@@ -306,7 +353,12 @@ class Localizer(InitializedPipelineStage):
         else:
             image_downsampled = image.astype(np.float32) / 255
 
-        saliencies = self.model.predict(image_downsampled[None, :, :, None])
+        # PyTorch NCHW inference; transpose output back to NHWC (1, H', W', C)
+        # so that all downstream indexing (saliencies[:, :, :, class_idx]) is unchanged.
+        img_t = torch.from_numpy(image_downsampled).float().unsqueeze(0).unsqueeze(0).to(self.device)
+        with torch.no_grad():
+            out = self.model(img_t)                          # (1, C, H', W')
+        saliencies = out.permute(0, 2, 3, 1).cpu().numpy()  # (1, H', W', C)
 
         bee_regions = []
         bee_saliencies = []

--- a/pipeline/stages/processing.py
+++ b/pipeline/stages/processing.py
@@ -12,12 +12,6 @@ from skimage.exposure import equalize_hist
 from skimage.feature import peak_local_max
 from skimage.io import imread
 
-# TensorFlow is still required for the Decoder stage (Keras ResNet).
-# TODO: migrate Decoder to PyTorch and remove this import
-#   (see bb_pipeline_models/models/model_generation/pipelinemodels.py → get_custom_resnet).
-import tensorflow as tf
-load_model = tf.keras.models.load_model
-
 from pipeline.objects import (
     BeeLocalizerPositions,
     BeeRegions,
@@ -40,21 +34,11 @@ from pipeline.objects import (
     TagSaliencies,
     Timestamp,
 )
+from pipeline.stages.decoder_torch import DecoderResNet
 from pipeline.stages.localizer_torch import LocalizerEncoder
 from pipeline.stages.stage import PipelineStage
 
 from bb_binary import parse_image_fname
-
-# Configure TF GPU memory growth for the Decoder.
-gpus = tf.config.experimental.list_physical_devices("GPU")
-if gpus:
-    try:
-        for gpu in gpus:
-            tf.config.experimental.set_memory_growth(gpu, True)
-        logical_gpus = tf.config.experimental.list_logical_devices("GPU")
-        print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
-    except RuntimeError as e:
-        print(e)
 
 
 def point_nms(positions, confidences, radius, class_names=None, class_agnostic=True):
@@ -426,10 +410,13 @@ class Decoder(InitializedPipelineStage):
 
     def __init__(self, model_path, use_hist_equalization=True):
         super().__init__()
-        self.model = load_model(model_path, compile=False)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = DecoderResNet().to(self.device)
+        self.model.load_state_dict(
+            torch.load(model_path, map_location=self.device, weights_only=True)
+        )
+        self.model.eval()
         self.uses_hist_equalization = use_hist_equalization
-
-        self.model.make_predict_function()
 
     def preprocess(self, regions):
         cropped_rois = regions[:, :, 34:-34, 34:-34]
@@ -439,7 +426,13 @@ class Decoder(InitializedPipelineStage):
         return cropped_rois[:, 0, :, :, None]
 
     def predict(self, regions):
-        predictions = self.model.predict(self.preprocess(regions), verbose=0)
+        preprocessed = self.preprocess(regions)  # (N, 32, 32, 1) NHWC
+        inputs = torch.from_numpy(
+            preprocessed.transpose(0, 3, 1, 2).astype(np.float32)
+        ).to(self.device)
+        with torch.no_grad():
+            outputs = self.model(inputs)
+        predictions = [t.cpu().numpy() for t in outputs]
 
         struct = np.empty(len(predictions[0]), dtype=self.types)
         struct["bits"] = np.stack(predictions[:12], -1)[:, 0, :]

--- a/pipeline/stages/processing.py
+++ b/pipeline/stages/processing.py
@@ -439,7 +439,7 @@ class Decoder(InitializedPipelineStage):
         return cropped_rois[:, 0, :, :, None]
 
     def predict(self, regions):
-        predictions = self.model.predict(self.preprocess(regions))
+        predictions = self.model.predict(self.preprocess(regions), verbose=0)
 
         struct = np.empty(len(predictions[0]), dtype=self.types)
         struct["bits"] = np.stack(predictions[:12], -1)[:, 0, :]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ pytest>=2.8.5
 pytest-cov>=2.2.1
 pytest-flake8>=0.5
 opencv-python>=4.1.0
+torch>=2.0
 git+https://github.com/BioroboticsLab/bb_binary.git


### PR DESCRIPTION
- Localizer: PyTorch `LocalizerEncoder` (FCN heatmap model), weights converted 
  from Keras via mosaic's `convert_keras_weights()`
- Decoder: new `DecoderResNet` in `decoder_torch.py` (custom ResNet-50), 
  with name-based H5→PT weight conversion
- POLO localizer: PyTorch/TorchScript
- All TF imports and GPU config removed from `processing.py`
- Config defaults updated to `.pt` weight files
- Verified: both models produce identical outputs to Keras (atol < 1e-4)